### PR TITLE
Ignore whitespace between elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ Changelog
 
 # 1.x release
 
-## v1.1.0 (master)
+## v1.2.0 (master)
+
+- Enhance: skip whitespace between child nodes to minimize vdom and reduce unnecessary patching
+
+## v1.1.0
 
 - Feature: allow optional attribute for key lookup
 

--- a/dist.js
+++ b/dist.js
@@ -121,6 +121,11 @@ function createVirtualDomNode(el, attr) {
 function createChildren(el, attr) {
 	var children = [];
 	for (var i = 0; i < el.childNodes.length; i++) {
+		// ignore whitespace text node between elements, this reduces vdom size and unnecessary patches
+		if (el.childNodes[i].nodeType === 3 && el.childNodes[i].nodeValue.trim() === '') {
+			continue;
+		}
+
 		children.push(createNode(el.childNodes[i], attr));
 	};
 

--- a/index.js
+++ b/index.js
@@ -120,6 +120,11 @@ function createVirtualDomNode(el, attr) {
 function createChildren(el, attr) {
 	var children = [];
 	for (var i = 0; i < el.childNodes.length; i++) {
+		// ignore whitespace text node between elements, this reduces vdom size and unnecessary patches
+		if (el.childNodes[i].nodeType === 3 && el.childNodes[i].nodeValue.trim() === '') {
+			continue;
+		}
+
 		children.push(createNode(el.childNodes[i], attr));
 	};
 

--- a/test/test.js
+++ b/test/test.js
@@ -530,4 +530,19 @@ describe('vdom-parser', function () {
 		expect(children[0].tagName).to.equal('P');
 		expect(children[0].key).to.equal('edf');
 	});
+
+	it('should skip whitespace textnode between elements', function () {
+		input = '<div> <p>a</p> <p>b</p>\t<p>c</p>\n<p>d</p>\r</div>';
+		output = parser(input);
+
+		expect(output.type).to.equal('VirtualNode');
+		expect(output.tagName).to.equal('DIV');
+
+		var children = output.children;
+		expect(children).to.have.length(4);
+		expect(children[0].type).to.equal('VirtualNode');
+		expect(children[1].type).to.equal('VirtualNode');
+		expect(children[2].type).to.equal('VirtualNode');
+		expect(children[3].type).to.equal('VirtualNode');
+	});
 });


### PR DESCRIPTION
To reduce vdom size and unnecessary patching.
