### PR TITLE
Use native CSS parsing

### DIFF
--- a/dist.js
+++ b/dist.js
@@ -37,7 +37,7 @@ function parser(el, attr) {
 
 		// most tags default to body
 		if (doc.body.firstChild) {
-			el = doc.body.firstChild;
+			el = doc.getElementsByTagName('body')[0].firstChild;
 
 		// some tags, like script and style, default to head
 		} else if (doc.head.firstChild && (doc.head.firstChild.tagName !== 'TITLE' || doc.title)) {
@@ -147,7 +147,17 @@ function createProperties(el) {
 
 	var attr;
 	for (var i = 0; i < el.attributes.length; i++) {
-		if (ns) {
+		// Use built in CSS style parsing
+		if(el.attributes[i].name == 'style'){
+			var style = el.style;
+			var output = {};
+			for (var i = 0; i < style.length; ++i) {
+				var item = style.item(i);
+				output[item] = style[item];
+			}
+			attr = {name: 'style', value: output};
+		}
+		else if (ns) {
 			attr = createPropertyNS(el.attributes[i]);
 		} else {
 			attr = createProperty(el.attributes[i]);
@@ -192,20 +202,8 @@ function createProperty(attr) {
 	} else {
 		name = attr.name;
 	}
-
-	// special cases for style attribute, we default to properties.style
-	if (name === 'style') {
-		var style = {};
-		attr.value.split(';').forEach(function (s) {
-			var pos = s.indexOf(':');
-			if (pos < 0) {
-				return;
-			}
-			style[s.substr(0, pos).trim()] = s.substr(pos + 1).trim();
-		});
-		value = style;
 	// special cases for data attribute, we default to properties.attributes.data
-	} else if (name.indexOf('data-') === 0) {
+	if (name.indexOf('data-') === 0) {
 		value = attr.value;
 		isAttr = true;
 	} else {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function parser(el, attr) {
 
 		// most tags default to body
 		if (doc.body.firstChild) {
-			el = doc.body.firstChild;
+			el = doc.getElementsByTagName('body')[0].firstChild;
 
 		// some tags, like script and style, default to head
 		} else if (doc.head.firstChild && (doc.head.firstChild.tagName !== 'TITLE' || doc.title)) {
@@ -146,7 +146,17 @@ function createProperties(el) {
 
 	var attr;
 	for (var i = 0; i < el.attributes.length; i++) {
-		if (ns) {
+		// Use built in CSS style parsing
+		if(el.attributes[i].name == 'style'){
+			var style = el.style;
+			var output = {};
+			for (var i = 0; i < style.length; ++i) {
+				var item = style.item(i);
+				output[item] = style[item];
+			}
+			attr = {name: 'style', value: output};
+		}
+		else if (ns) {
 			attr = createPropertyNS(el.attributes[i]);
 		} else {
 			attr = createProperty(el.attributes[i]);
@@ -191,20 +201,8 @@ function createProperty(attr) {
 	} else {
 		name = attr.name;
 	}
-
-	// special cases for style attribute, we default to properties.style
-	if (name === 'style') {
-		var style = {};
-		attr.value.split(';').forEach(function (s) {
-			var pos = s.indexOf(':');
-			if (pos < 0) {
-				return;
-			}
-			style[s.substr(0, pos).trim()] = s.substr(pos + 1).trim();
-		});
-		value = style;
 	// special cases for data attribute, we default to properties.attributes.data
-	} else if (name.indexOf('data-') === 0) {
+	if (name.indexOf('data-') === 0) {
 		value = attr.value;
 		isAttr = true;
 	} else {

--- a/test/test.js
+++ b/test/test.js
@@ -184,7 +184,7 @@ describe('vdom-parser', function () {
 	});
 
 	it('should parse bracket style attribute on node', function () {
-		input = '<div style="color: red; width: 100px; background-url: url(test.jpg)">test</div>';
+		input = '<div style="color: red; width: 100px; background-image: url(test.jpg)">test</div>';
 		output = parser(input);
 
 		expect(output.type).to.equal('VirtualNode');
@@ -192,9 +192,21 @@ describe('vdom-parser', function () {
 		expect(output.properties.style).to.eql({
 			color: 'red'
 			, width: '100px'
-			, 'background-url': 'url(test.jpg)'
+			, 'background-image': 'url(test.jpg)'
 		});
 	});
+
+	it('should parse base64 encoded styles on node', function () {
+		var background = 'url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7)';
+		input = '<div style="background-image: ' + background + '">test</div>';
+		output = parser(input);
+		expect(output.type).to.equal('VirtualNode');
+		expect(output.tagName).to.equal('DIV');
+		expect(output.properties.style).to.eql({
+			'background-image': background
+		});
+	});
+
 
 	it('should parse data attribute on node', function () {
 		input = '<div data-my-attr="abc">test</div>';


### PR DESCRIPTION
Hello @bitinn 

I recently created a library similar to vdom-parser at https://github.com/AkeemMcLennon/dom2hscript

I noticed your version had bug where it failed to parse certain CSS properties that contained semicolons such a base64 encoded strings. This pull request uses the browser's native css parser to improve accuracy.
