### PR TITLE
Fix issue when parsing style

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,17 +152,7 @@ function createProperties(el) {
 	for (var i = 0; i < el.attributes.length; i++) {
 		// use built in css style parsing
 		if(el.attributes[i].name == 'style'){
-			var style = el.style;
-			var output = {};
-			for (var i = 0; i < style.length; ++i) {
-				var item = style.item(i);
-				output[item] = style[item];
-				// hack to workaround browser inconsistency with url()
-				if (output[item].indexOf('url') > -1) {
-					output[item] = output[item].replace(/\"/g, '')
-				}
-			}
-			attr = {name: 'style', value: output};
+			attr = createStyleProperty(el);
 		}
 		else if (ns) {
 			attr = createPropertyNS(el.attributes[i]);
@@ -238,4 +228,24 @@ function createPropertyNS(attr) {
 		, value: attr.value
 		, ns: namespaceMap[attr.name] || ''
 	};
+}
+
+/**
+ * Create style property from dom node
+ *
+ * @param   Object  el  DOM node
+ * @return  Object        Normalized attribute
+ */
+function createStyleProperty(el) {
+	var style = el.style;
+	var output = {};
+	for (var i = 0; i < style.length; ++i) {
+		var item = style.item(i);
+		output[item] = style[item];
+		// hack to workaround browser inconsistency with url()
+		if (output[item].indexOf('url') > -1) {
+			output[item] = output[item].replace(/\"/g, '')
+		}
+	}
+	return { name: 'style', value: output };
 }

--- a/test/test.js
+++ b/test/test.js
@@ -161,7 +161,7 @@ describe('vdom-parser', function () {
 	});
 
 	it('should parse style attribute on node', function () {
-		input = '<div style="color: red;">test</div>';
+		input = '<div style="color: red;" id="abc">test</div>';
 		output = parser(input);
 
 		expect(output.type).to.equal('VirtualNode');
@@ -169,6 +169,7 @@ describe('vdom-parser', function () {
 		expect(output.properties.style).to.eql({
 			color: 'red'
 		});
+		expect(output.properties.id).to.equal('abc');
 	});
 
 	it('should parse complex style attribute on node', function () {


### PR DESCRIPTION
Hi @bitinn,

Found an issue when parsing the style of an element that has more attributes than style properties, egg:

```
<input id="main" class="valid" style="display: none;">
```

The cause is the nested `for` in https://github.com/bitinn/vdom-parser/blob/master/index.js#L157 using the same variable as the outer `for`.

This is a possible solution,
Cheers!
