### PR TITLE
Fixed bug that caused #createStyleProperty to fail sometimes

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ function createStyleProperty(el) {
 	var output = {};
 	for (var i = 0; i < style.length; ++i) {
 		var item = style.item(i);
-		output[item] = style[item];
+		output[item] = String(style[item]);
 		// hack to workaround browser inconsistency with url()
 		if (output[item].indexOf('url') > -1) {
 			output[item] = output[item].replace(/\"/g, '')

--- a/test/test.js
+++ b/test/test.js
@@ -196,6 +196,17 @@ describe('vdom-parser', function () {
 		expect(output.properties.style['background-image']).to.equal(url);
 	});
 
+	it('should always parse numeric style properties as string', function () {
+		input = '<div style="z-index:42">test</div>';
+		output = parser(input);
+
+		expect(output.type).to.equal('VirtualNode');
+		expect(output.tagName).to.equal('DIV');
+		expect(output.properties.style).to.eql({
+			'z-index': '42'
+		});
+	});
+
 	it('should parse base64 encoded styles on node', function () {
 		var url = 'url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7)';
 		input = '<div style="background: ' + url + '">test</div>';


### PR DESCRIPTION
It seems like `#createStyleProperty` fails if `style[item]` contains a numeric value. This happens in IE11 for `z-index`, for instance. Casting the value prior to doing the `url()` workaround should do the trick. It also leads to a consistence property type across various browsers